### PR TITLE
Dynamic generation of Grid columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,20 @@ You can customize how many widget tabs appear in each row by overriding the `get
 class:
 
 ```php
- protected function getWidgetsPerRow(): int 
+ protected function getWidgetsPerRow(): int|array
  { 
     return 4; // Default is 3 widgets per row
  }
 ```
+It is also possible to specify an array of breakpoints for different display sizes:
+
+```php
+ protected function getWidgetsPerRow(): int|array
+ { 
+    return ['sm'=>2, 'md'=>3, 'lg'=>4];
+ }
+```
+
 
 ### Labels
 

--- a/resources/views/components/widget-tabs/index.blade.php
+++ b/resources/views/components/widget-tabs/index.blade.php
@@ -1,15 +1,59 @@
 @php
     $widgetsPerRow = $this->getWidgetsPerRow();
+    if (!is_array($widgetsPerRow)) {
+        $widgetsPerRow = [
+            'md' => $widgetsPerRow,
+        ];
+    }
+    $columns = collect([
+        ...[
+            'default' => 1,
+            'sm' => 2,
+            'md' => 3,
+            'lg' => null,
+            'xl' => null,
+            '2xl' => null,
+        ],
+        ...$widgetsPerRow,
+    ]);
+    $classes = $columns
+        ->filter()
+        ->keys()
+        ->map(
+            fn($key): string => str($key)
+                ->whenIs(
+                    'default',
+                    fn($string) => $string->replace($key, 'grid-cols-[--cols-'),
+                    fn($string) => $string->append(':grid-cols-[--cols-'),
+                )
+                ->append($key)
+                ->finish(']')
+                ->value(),
+        )
+        ->all();
+    $columns = $columns
+        ->mapWithKeys(
+            fn($value, $key): array => [
+                str($key)
+                    ->start('--cols-')
+                    ->append(': repeat(')
+                    ->append($value)
+                    ->finish(', minmax(0, 1fr))')
+                    ->value() => $value,
+            ],
+        )
+        ->filter()
+        ->all();
 @endphp
 
 <div
-    {{
-        $attributes
-            ->merge(['role' => 'tablist'])
-            ->class([
-                "fi-widget-tabs grid grid-cols-1 sm:grid-cols-2 md:grid-cols-$widgetsPerRow gap-4",
+    {{ $attributes
+        ->merge(['role' => 'tablist'])
+        ->class([
+            'fi-widget-tabs grid',
+            ...$classes,
+            'gap-4'
             ])
-    }}
->
+            ->style($columns) }}>
     {{ $slot }}
 </div>

--- a/src/Concerns/HasWidgetTabs.php
+++ b/src/Concerns/HasWidgetTabs.php
@@ -88,8 +88,13 @@ trait HasWidgetTabs
             ->replace(['_', '-'], ' ')
             ->ucfirst();
     }
-
-    public function getWidgetsPerRow(): int
+    /**
+     * Use an integer value, or an array with breakpoints and integer values
+     *  ['sm'=>2, 'md'=>3, 'lg'=>4] or 3
+     *
+     * @return integer|array<string, int>
+     */
+    public function getWidgetsPerRow(): int|array
     {
         return 3;
     }


### PR DESCRIPTION
I've extended the view so that the number of tabs per row can be specified more dynamically, sorted by breakpoint.

This eliminates the need to create the view separately.

For this, the return of the getWidgetsPerRow() method also had to be changed.